### PR TITLE
Add the ability to ignore values

### DIFF
--- a/testdata/values.yaml
+++ b/testdata/values.yaml
@@ -167,3 +167,7 @@ additionalPodSecurityPolicies: []
 platform:
   # Set true, if installed in OpenShift
   openshift: false
+
+toIgnore: # +doc-gen:ignore
+  foo: true
+toIgnore2: false # +doc-gen:ignore

--- a/walk/map.go
+++ b/walk/map.go
@@ -46,7 +46,10 @@ func (l Walker) walkMap() (*yaml.RNode, error) {
 			if err != nil {
 				return nil, err
 			}
-
+			ignore := CommentValue(field.Key.YNode().LineComment) == "+doc-gen:ignore" || CommentValue(field.Value.YNode().LineComment) == "+doc-gen:ignore"
+			if ignore {
+				continue
+			}
 			breakout := CommentValue(field.Key.YNode().LineComment) == "+doc-gen:break"
 			if field.Value.YNode().Kind == yaml.ScalarNode ||
 				yaml.IsEmpty(field.Value) ||


### PR DESCRIPTION
implements #10 
Adds a special key (`+doc-gen:ignore`) to allow ignoring a section in the values.yaml file.
example:
```yaml
platform:
  # Set true, if installed in OpenShift
  openshift: false

toIgnore: # +doc-gen:ignore
  foo: true
toIgnore2: false # +doc-gen:ignore
```